### PR TITLE
allow CI to fail

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,6 @@ jobs:
     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
Closes #181 

I am not sure why we had it in the first place, given we have only one job anyway.