### PR TITLE
troubleshooting Wuhan failure in CI [2025-05-23]

### DIFF
--- a/neatnet/tests/conftest.py
+++ b/neatnet/tests/conftest.py
@@ -46,6 +46,7 @@ KNOWN_BAD_GEOMS = {
     "douala_809": [],
     "liege_1656": [921],
     "slc_4881": [1144, 1146],
+    "wuhan_8989": [],
     "apalachicola_standard": [324],
     "apalachicola_exclusion_mask": [],
 }


### PR DESCRIPTION
* add empty wuhan list to `KNOWN_BAD_GEOMS`
* we can already tell some fishy is going on from the difference plot from the CI artifacts -- with wuhan added to [`KNOWN_BAD_GEOMS`](https://github.com/uscuni/neatnet/blob/03a33a326fd33af891fc94620eb97d43e1f18f62/neatnet/tests/conftest.py#L42) the test can complete

![wuhan_8989](https://github.com/user-attachments/assets/8e8a1d40-8f27-4c0d-a9c6-138ea5415bc1)
