### PR TITLE
 remove `buffer=clip_limit` passed into `voronoi_skeleton()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 ---
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.8"
+    rev: "v0.11.13"
     hooks:
-      - id: ruff
+      - id: ruff-check
         files: "neatnet\/|docs\/source\/"
       - id: ruff-format
         files: "neatnet\/|docs\/source\/"

--- a/neatnet/artifacts.py
+++ b/neatnet/artifacts.py
@@ -779,7 +779,6 @@ def one_remaining(
             poly=artifact.geometry,
             snap_to=relevant_targets.geometry.iloc[target_nearest],  # snap to nearest
             max_segment_length=max_segment_length,
-            buffer=clip_limit,  # TODO: figure out if we need this
             clip_limit=clip_limit,
             consolidation_tolerance=consolidation_tolerance,
         )


### PR DESCRIPTION
This MR:
* resolves #12 
* removes `buffer=clip_limit` [here](https://github.com/uscuni/neatnet/blob/4dee12fe920aa0d17d6c904ee055f411eb2c00d8/neatnet/artifacts.py#L782) in `one_remaining()`
* has no affect on testing (including Wuhan)
* worth noting that we also don't pass `buffer` into `voronoi_skeleton()` within [`multiple_remaining()`](https://github.com/uscuni/neatnet/blob/4dee12fe920aa0d17d6c904ee055f411eb2c00d8/neatnet/artifacts.py#L845-L853) or [`one_remaining_c()`](https://github.com/uscuni/neatnet/blob/4dee12fe920aa0d17d6c904ee055f411eb2c00d8/neatnet/artifacts.py#L921-L928)