### PR TITLE
update macOS image for intel in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
         ]
         include:
           - environment-file: py313_latest
-            os: macos-13  # Intel
+            os: macos-15-intel  # Intel
           - environment-file: py313_latest
             os: macos-latest  # Apple Silicon
           - environment-file: py313_latest


### PR DESCRIPTION
* update macOS image for intel in CI
* [`py313_dev`](https://github.com/uscuni/neatnet/actions/runs/20200220945/job/57990236307?pr=282) failure related to [#281](#281 ), ***not*** the `macOS-15-intel` image.
